### PR TITLE
Fix prompts not displaying in UI

### DIFF
--- a/api/src/routes/promptRoutes.ts
+++ b/api/src/routes/promptRoutes.ts
@@ -77,12 +77,28 @@ router.post('/', authenticateUser, async (req: Request, res: Response) => {
   }
 });
 
-// Get all prompts for a user
+// Get all prompts for a user (including system prompts)
 router.get('/', authenticateUser, async (req: Request, res: Response) => {
   try {
     const user = (req as any).user;
+    
+    // Find system user for system prompts
+    const systemUser = await userRepository.findOne({
+      where: { email: 'system@platform.com' }
+    });
+
+    // Build where conditions - include user's own prompts and system prompts
+    const whereConditions = [
+      { userId: user.id } // User's own prompts
+    ];
+
+    // Add system prompts if system user exists
+    if (systemUser) {
+      whereConditions.push({ userId: systemUser.id });
+    }
+
     const prompts = await promptRepository.find({
-      where: { userId: user.id },
+      where: whereConditions,
       relations: ['versions'],
       order: { createdAt: 'DESC' }
     });

--- a/api/src/utils/seedDatabase.ts
+++ b/api/src/utils/seedDatabase.ts
@@ -321,11 +321,21 @@ export const seedDatabase = async (): Promise<void> => {
     console.log('Creating prompts...');
     // Create prompts from fixtures
     if (fixtures.prompts) {
+      // Find the system user for system prompts
+      const systemUser = await userRepository.findOne({
+        where: { email: 'system@platform.com' }
+      });
+
       for (const promptData of fixtures.prompts) {
         try {
+          // Handle system prompts - use system user ID if userId is "system"
+          const promptUserId = promptData.userId === 'system' && systemUser
+            ? systemUser.id
+            : savedUser!.id;
+
           const prompt = promptRepository.create({
             ...promptData,
-            userId: savedUser!.id
+            userId: promptUserId
           });
           await promptRepository.save(prompt);
         } catch (error) {


### PR DESCRIPTION
## Problem\n\nPrompts were not displaying in the UI even though they existed in the database. The issue was that:\n\n1. Prompts were being associated with the first user (michael@tunnel.ninja) instead of the system user\n2. The API only returned prompts for the currently authenticated user\n3. System prompts should be visible to all users\n\n## Solution\n\n1. **Fixed seeding logic**: Updated  to properly handle prompts with  by associating them with the system user ()\n2. **Updated API**: Modified  to include system prompts for all authenticated users\n3. **Re-seeded database**: Cleared and re-seeded the database to fix prompt ownership\n\n## Testing\n\n- ✅ API now returns 7 prompts for both admin@platform.com and michael@tunnel.ninja users\n- ✅ All prompts are properly associated with system@platform.com\n- ✅ UI should now display prompts for all authenticated users\n\n## Changes\n\n- : Fixed prompt user assignment logic\n- : Added system prompts to API response\n\nCloses #15